### PR TITLE
Fix Purview script_archive folder commit message

### DIFF
--- a/script_archive/.gitkeep
+++ b/script_archive/.gitkeep
@@ -1,2 +1,3 @@
 # PAX Script Archive
+# Re-updated after purview-v1.7.0
 

--- a/script_archive/Purview_Audit_Log_Processor/.gitkeep
+++ b/script_archive/Purview_Audit_Log_Processor/.gitkeep
@@ -1,1 +1,3 @@
-# Purview Script Archive
+# Purview Audit Log Processor - Script Archive
+# Updated: v1.7.0
+


### PR DESCRIPTION
Updates Purview_Audit_Log_Processor subfolder to show purview-v1.7.0 commit message while maintaining parent script_archive folder at PAX-v1.0.2.