### PR TITLE
Fix: Documentation link in purview-v1.8.0 release note

### DIFF
--- a/release_notes/.gitkeep
+++ b/release_notes/.gitkeep
@@ -1,1 +1,1 @@
-# Last updated: 2025-11-10 (PAX v1.0.7, Graph v1.0.1, Purview v1.8.0)
+# Last updated: 2025-11-11 (PAX v1.0.7, Graph v1.0.1, Purview v1.8.0)

--- a/release_notes/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Release_Note_v1.8.0.md
+++ b/release_notes/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Release_Note_v1.8.0.md
@@ -1153,7 +1153,7 @@ If you see partitions listed as "Sent but Incomplete" or "Never Sent" in the sum
 
 For questions or issues, refer to the documentation:
 
-- **Documentation v1.8.0 (Markdown):** [PAX_Purview_Audit_Log_Processor_Documentation_v1.8.0.md](https://github.com/microsoft/PAX/releases/download/purview-v1.8.0/PAX_Purview_Audit_Log_Processor_Documentation_v1.8.0.md)
+- **Documentation v1.8.0 (Markdown):** [PAX_Purview_Audit_Log_Processor_Documentation_v1.8.0.md](https://github.com/microsoft/PAX/blob/release/release_documentation/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Documentation_v1.8.0.md)
 
 *Managed and released by the Microsoft Copilot Growth ROI Advisory Team. Please reach out to [copilot-roi-advisory-team-gh@microsoft.com](mailto:copilot-roi-advisory-team-gh@microsoft.com) with any feedback.*
 


### PR DESCRIPTION
This PR fixes the documentation link in the purview-v1.8.0 release note and updates the release_notes/.gitkeep file.

**Commits:**
- purview-v1.8.0: Fixed documentation link (releases/download → blob/release)
- PAX-v1.0.7: Updated release_notes/.gitkeep

**Files changed:**
1. release_notes/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Release_Note_v1.8.0.md
2. release_notes/.gitkeep