### PR TITLE
Updated README.md layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
 
 # Portable Audit eXporter (PAX) Solution Set
 
-<a href="https://github.com/microsoft/PAX/blob/release/release_documentation/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Documentation_v1.11.x.md">
-  <img src="assets/pax-logo.png" alt="PAX — Portable Audit eXporter" height="85" align="middle">
-</a>
+<a href="https://github.com/microsoft/PAX/blob/release/release_documentation/Purview_Audit_Log_Processor/PAX_Purview_Audit_Log_Processor_Documentation_v1.11.x.md"><img src="assets/pax-logo.png" alt="PAX Portable Audit eXporter" height="85" align="middle"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-<a href="https://microsoft.github.io/PAX-Cookbook">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/pax-cookbook-logo-horizontal-white.png">
-    <source media="(prefers-color-scheme: light)" srcset="assets/pax-cookbook-logo-horizontal-blue.png">
-    <img src="assets/pax-cookbook-logo-horizontal-blue.png" alt="PAX Cookbook" height="85" align="middle">
-  </picture>
-</a>
+<a href="https://microsoft.github.io/PAX-Cookbook"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/pax-cookbook-logo-horizontal-white.png"><source media="(prefers-color-scheme: light)" srcset="assets/pax-cookbook-logo-horizontal-blue.png"><img src="assets/pax-cookbook-logo-horizontal-blue.png" alt="PAX Cookbook" height="85" align="middle"></picture></a>
 
 <br>
 


### PR DESCRIPTION
Removes a stray dash that appeared between the header logos. The dash came from the PAX logo image's alt text surfacing as a text node due to whitespace inside the anchor; the fix collapses each logo anchor onto a single line and drops the em-dash from the alt text. No visual/layout change to the logos themselves.